### PR TITLE
Piece mapping and captures (except for pawns) for notations

### DIFF
--- a/src/game/notation.rs
+++ b/src/game/notation.rs
@@ -6,6 +6,7 @@ pub struct Notation {
     rank: u8,
     file: u8,
     piece_type: PieceType,
+    capture: bool
 }
 
 fn decode_coordinate(notation: &str, reverse_index: usize, parse_radix: u32, parse_offset: u32, coordinate_name: &str, valid_range: &str) -> u8 {
@@ -54,18 +55,37 @@ fn decode_file(notation: &str) -> u8 {
     decode_coordinate(notation, 1, 18, 10, "file", "a..h")
 }
 
-fn decode_piecetype(notation: &str) -> PieceType {
+fn decode_piecetype_character(notation: &str, piecetype_character: char) -> PieceType{
+    match piecetype_character {
+        'K' => PieceType::King,
+        'Q' => PieceType::Queen,
+        'B' => PieceType::Bishop,
+        'R' => PieceType::Rook,
+        'N' => PieceType::Knight,
+        _ => panic!("Invalid piece {} in move notation: {}. Must be none, K, Q, R, B or N", piecetype_character, notation)
+    }
+}
 
-    let invalid = | what: &str | panic!("Invalid piece {} in move notation: {}. Must be none, K, Q, R, B or N", what, notation);
-    match notation.chars().rev().nth(2) {
+fn decode_piecetype(notation: &str) -> PieceType {
+    let mut chars = notation.chars().rev();
+    match chars.nth(2) {
         None => PieceType::Pawn,
         Some(x) => match x {
-            'K' => PieceType::King,
-            'Q' => PieceType::Queen,
-            'B' => PieceType::Bishop,
-            'R' => PieceType::Rook,
-            'N' => PieceType::Knight,
-            _ => invalid(&x.to_string())
+            'x' => match chars.nth(0) {
+                None => panic!("Missing piece indicator in capture move notation: {}", notation),
+                Some(y) => decode_piecetype_character(notation, y)
+            },
+            _ => decode_piecetype_character(notation, x)
+        }
+    }
+}
+
+fn decode_capture(notation: &str) -> bool {
+    match notation.chars().rev().nth(2) {
+        None => false,
+        Some(x) => match x {
+            'x' => true,
+            _ => false
         }
     }
 }
@@ -75,11 +95,13 @@ pub fn decode(notation: String) -> Notation {
     let rank = decode_rank(&notation);
     let file = decode_file(&notation);
     let piece_type = decode_piecetype(&notation);
+    let capture = decode_capture(&notation);
     Notation {
         text: notation.to_string(),
         rank: rank,
         file: file,
-        piece_type: piece_type
+        piece_type: piece_type,
+        capture: capture
     }
 }
 
@@ -87,6 +109,18 @@ pub fn decode(notation: String) -> Notation {
 mod tests {
 
     use super::*;
+
+    fn build_expected(mutation: impl Fn(&mut Notation)) -> Notation {
+        let mut result = Notation {
+            text: "a1".to_string(),
+            file: 0,
+            rank: 0,
+            piece_type: PieceType::Pawn,
+            capture: false
+        };
+        mutation(&mut result);
+        result
+    }
 
     #[test]
     #[should_panic(expected="Missing file")]
@@ -137,12 +171,13 @@ mod tests {
     #[test]
     fn translate_rank_and_file() {
         let notation = "e4";
-        let expected = Notation {
-            text: notation.to_string(),
-            rank: 3,
-            file: 4,
-            piece_type: PieceType::Pawn
-        };
+        let expected = build_expected(|x| {
+            x.text = notation.to_string();
+            x.rank = 3;
+            x.file = 4;
+            x.piece_type = PieceType::Pawn;
+        });
+
         let actual = decode(notation.to_string());
         assert_eq!(expected, actual);
     }
@@ -150,12 +185,12 @@ mod tests {
     #[test]
     fn translate_rank_and_file_upper_bounds() {
         let notation = "h8";
-        let expected = Notation {
-            text: notation.to_string(),
-            rank: 7,
-            file: 7,
-            piece_type: PieceType::Pawn
-        };
+        let expected = build_expected(|mut x| {
+            x.text = notation.to_string();
+            x.rank = 7;
+            x.file = 7;
+            x.piece_type = PieceType::Pawn;
+        });
         let actual = decode(notation.to_string());
         assert_eq!(expected, actual);
     }
@@ -163,12 +198,12 @@ mod tests {
     #[test]
     fn translate_rank_and_file_lower_bounds() {
         let notation = "a1";
-        let expected = Notation {
-            text: notation.to_string(),
-            rank: 0,
-            file: 0,
-            piece_type: PieceType::Pawn
-        };
+        let expected = build_expected(|mut x| {
+            x.text = notation.to_string();
+            x.rank = 0;
+            x.file = 0;
+            x.piece_type = PieceType::Pawn;
+        });
         let actual = decode(notation.to_string());
         assert_eq!(expected, actual);
     }
@@ -192,5 +227,17 @@ mod tests {
             let actual = decode(notation.to_string());
             assert_eq!(actual.piece_type, *piece_type);
         }
+    }
+
+    #[test]
+    fn when_a_capture_symbol_is_used_for_a_named_piece() {
+        let notation = "Kxa1";
+        let expected = build_expected(|mut x| {
+            x.text = notation.to_string();
+            x.piece_type = PieceType::King;
+            x.capture = true;
+        });
+        let actual = decode(notation.to_string());
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Algebraic_notation_(chess) this maps the indicated piece in a notated move or assumes a pawn if not specified. It also notes whether or not a capture is indicated.

In other words:
"e4" should be a Pawn, not capturing anything
"Ka1" should be a King
"Kxa1" should be a King capturing the piece on a1